### PR TITLE
added prefix to library resources

### DIFF
--- a/androidtoggleswitch/build.gradle
+++ b/androidtoggleswitch/build.gradle
@@ -10,6 +10,7 @@ ext {
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.3"
+    resourcePrefix 'toggle_switch'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
I needed to add resouces prefix as some names are conflicting with files in big project we are using this library for. Its goood practise to add the prefix for resources in library, i guess i am not the only one facing that problem. I would be very thankfull if you could merge and release new version with this update as i dont want to fork and make it dependend on my fork if your version is maintained.